### PR TITLE
removed relative paths from cli script

### DIFF
--- a/model/framework/code/cli.py
+++ b/model/framework/code/cli.py
@@ -2,6 +2,10 @@ import os
 import pandas as pd
 from rdkit import Chem
 import numpy as np
+import sys
+
+root = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(root)
 
 #Function to extract the pKa values from the sdf file and wirte them in a csv file
 def extract_pka_statistics_from_sdf(sdf_file, csv_file, no_protonation):
@@ -81,7 +85,7 @@ import argparse
 import logging
 import sys
 
-from ._version import get_versions
+from _version import get_versions
 
 __version__ = get_versions()["version"]
 
@@ -368,7 +372,7 @@ def run_pipeline(args):
     args : argparse.Namespace
         Command line arguments.
     """
-    from .predict import run_prediction_pipeline
+    from predict import run_prediction_pipeline
 
     args.output = check_output_file(args.output, args.root)
     args.mp = args.multiprocessing


### PR DESCRIPTION
Hi @LauraGomezjurado I have quickly tried a solution for your relative paths issue. Let's see if it works (I haven't tested it yet). Basically, I added the current script directory to the python paths, and then I import the versions and the get predictions models with an absolute import (i.e., without the dot) instead of a relative import (i.e. with the dot)