### PR TITLE
reconstruct conda path

### DIFF
--- a/model/framework/run.sh
+++ b/model/framework/run.sh
@@ -2,7 +2,8 @@ cwd=$(pwd)
 input_path=$(realpath "$2")
 output_path=$(realpath "$3")
 cd $1
-qupkake file $input_path -s smiles -o intermediate_output.sdf
+conda_env_path=$(dirname $(dirname "$python_path"))
+$conda_env_path/bin/qupkake file $input_path -s input -o intermediate_output.sdf
 python code/postprocess.py data/output/intermediate_output.sdf $output_path
 rm -rf data
 cd $cwd


### PR DESCRIPTION
Hi @LauraGomezjurado as it turns out, qupkake was not findable from the run.sh (for some weird conda reason). So I have explicitly put the path. This should work but I haven't checked.
Also, I have modified the -s option to look for input instead of smiles as column name, since in the service.py we were storing the file dynamically with input as header, not smiles. No big deal.